### PR TITLE
files which are needed to bring the wifi and prpl mesh automatically

### DIFF
--- a/prplmesh_startup.service
+++ b/prplmesh_startup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Prpl startup
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash /bin/prplmesh_startup.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/prplmesh_startup.sh
+++ b/prplmesh_startup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "/home/root/prplmesh_startup.sh ran at $(date)!" > /tmp/prpl-debug
+echo $(hostapd /usr/ccsp/wifi/hostapd0.conf) >> /tmp/prpl-debug
+sleep 5
+echo $(/opt/prplmesh/scripts/prplmesh_utils.sh start) >> /tmp/prpl-debug
+


### PR DESCRIPTION
The following files were proposed to be used in the RDK-B system of RPi to be able to start the prplmesh automatically during bootup. 
A recipe must be made to install these files to their correct location during the build. 
Signed-off-by: aswath <aswath2481@outlook.com>

https://jira.prplfoundation.org/browse/PPM-245